### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "webpack-dev-server": "^3.1.10",
     "webpack-merge": "^4.1.4",
     "yarn-run-all": "^3.1.1"
+  },
+  "resolutions": {
+    "**/event-stream": "^4.0.1"
   }
 }


### PR DESCRIPTION
"yarn install" with master package.json would fail due to the event-stream incident described below: https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident

The recommended change to package.json resolves the issue and allows "yarn install" to complete successfully. 